### PR TITLE
Document local Things 3 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # things3_mcp
+
+This project aims to automate managing Tasks in Cultured Code's Things 3. The server talks to the local Things app using AppleScript. Basic actions can also be triggered through the [Things URL scheme](https://culturedcode.com/things/support/articles/2803573/) when convenient.
+
+Authentication is optional. By default the server only listens on localhost, but an API token can be configured if remote clients need access.
+
+For more details see [docs/PRD.md](docs/PRD.md) and Apple's [Introduction to AppleScript](https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptX/AppleScriptX.html).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,13 @@
+# Things 3 Integration
+
+This document answers open questions about how the server will access data in Things 3 and which automation tools will be used.
+
+## Automation interface
+
+The server communicates with the local Things 3 application primarily through AppleScript. AppleScript allows reading tasks, creating new items, and triggering other advanced features that are not exposed through the URL scheme.
+
+For simple actions like adding a to‑do or opening a specific list, the optional Things URL scheme may be used. This scheme is suitable for lightweight operations but does not provide full access to metadata.
+
+## Authentication and security
+
+The integration is intended to run on the same machine where Things 3 is installed. Because it is local‑only by default, no authentication is strictly required. If the server is exposed beyond localhost, an optional API token should be configured so that only authorized clients can interact with the automation scripts.


### PR DESCRIPTION
## Summary
- outline how the server integrates with Things 3 via AppleScript
- note that the URL scheme can still be used for simple actions
- mention local-only access and optional API token for authentication
- document these decisions in README and PRD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e4b89c49c833291af7f0811215920